### PR TITLE
Use mbstring functions instead of deprecated utf8 functions

### DIFF
--- a/libs/class_product_backlog.php
+++ b/libs/class_product_backlog.php
@@ -44,7 +44,7 @@ class gadiv_productBacklog extends gadiv_commonlib {
 		global $agilemantis_au;
 		
 		// Check if team-user name fits into MantisBT regulations
-		if ( ! ( utf8_strlen( $this->name ) <  22 // field size minus length of prefix  
+		if ( ! ( mb_strlen( $this->name ) <  22 // field size minus length of prefix
 				&& user_is_name_valid( $this->name ) 
 				&& user_is_name_unique( $this->name )  ) ) {
 			


### PR DESCRIPTION
utf8 functions like utf8_strlen will be deprecated in MantisBT 2.13.0 [1]

The functions are still supported but will generate DEPRCECATED messages in PHP logs.
The functions are no longer needed as we made `mbstring` a mandatory PHP extension.

[1] https://mantisbt.org/bugs/view.php?id=23214